### PR TITLE
Update Terra Classic api and rpc to the correct one

### DIFF
--- a/chains/mainnet/terra.json
+++ b/chains/mainnet/terra.json
@@ -1,8 +1,8 @@
 {
     "chain_name": "terra-luna",
     "coingecko": "terra-luna",
-    "api": "https://fcd.terra.dev",
-    "rpc": ["https://terra-rpc.easy2stake.com:443", "http://public-node.terra.dev:26657"],
+    "api": "https://terra-classic-fcd.publicnode.com",
+    "rpc": ["https://terra-rpc.easy2stake.com:443", "https://terra-classic-rpc.publicnode.com"],
     "snapshot_provider": "",
     "sdk_version": "0.44.2",
     "coin_type": "330",


### PR DESCRIPTION
TFL endpoints redirect all requests to the PublicNode ones. Real infra provider should be displayed.