### PR TITLE
Remove Trivium's Archway endpoints

### DIFF
--- a/chains/mainnet/archway.json
+++ b/chains/mainnet/archway.json
@@ -3,14 +3,12 @@
     "api": [
         "https://api.mainnet.archway.io",
         "https://api-1.archway.nodes.guru",
-        "https://api.archway.nodestake.top",
-        "https://archway.api.trivium.network:1317"
+        "https://api.archway.nodestake.top"
     ],
     "rpc": [
         "https://rpc.mainnet.archway.io:443",
         "https://rpc-1.archway.nodes.guru/",
-        "https://rpc.archway.nodestake.top/",
-        "https://archway.api.trivium.network:26657"
+        "https://rpc.archway.nodestake.top/"
     ],
     "snapshot_provider": "https://snapshots.archway.tech/",
     "sdk_version": "v0.45.16",

--- a/chains/testnet/archway.json
+++ b/chains/testnet/archway.json
@@ -1,12 +1,10 @@
 {
     "chain_name": "archway",
     "api": [
-        "https://api.constantine.archway.tech",
-        "https://constantine.api.trivium.network:1317"
+        "https://api.constantine.archway.tech"
     ],
     "rpc": [
-        "https://rpc.constantine.archway.tech",
-        "https://constantine.api.trivium.network:26657"
+        "https://rpc.constantine.archway.tech"
     ],
     "snapshot_provider": "https://snapshots.archway.tech/",
     "sdk_version": "v0.45.16",


### PR DESCRIPTION
Trivium has discontinued our Archway services.