### PR TITLE
Update API and RPC providers in source.json

### DIFF
--- a/chains/mainnet/source.json
+++ b/chains/mainnet/source.json
@@ -1,64 +1,24 @@
 {
   "chain_name": "source",
   "coingecko": "source",
-  "api": [
-    {
-      "provider": "NodeStake",
-      "address": "https://api.source.nodestake.top"
-    },
-    {
-      "provider": "KJNodes",
-      "address": "https://source.api.kjnodes.com"
-    },
+   "api": [
     {
       "provider": "TCNetwork",
       "address": "https://rest.source.tcnetwork.io"
     },
     {
-      "provider": "MoonBridge",
-      "address": "https://source.api.moonbridge.team"
-    },
-    {
-      "provider": "Nodeist",
-      "address": "https://api-source.nodeist.net"
-    },
-    {
-      "provider": "ITRocket",
-      "address": "https://source-mainnet-api.itrocket.net:443"
-    },
-    {
-      "provider": "StakeTown",
-      "address": "https://source-api.stake-town.com:443"
+      "provider": "Polkachu",
+      "address": "https://source-api.polkachu.com"
     }
   ],
   "rpc": [
-    {
-      "provider": "NodeStake",
-      "address": "https://rpc.source.nodestake.top"
-    },
-    {
-      "provider": "KJNodes",
-      "address": "https://source.rpc.kjnodes.com"
-    },
     {
       "provider": "TCNetwork",
       "address": "https://rpc.source.tcnetwork.io"
     },
     {
-      "provider": "MoonBridge",
-      "address": "https://source.rpc.moonbridge.team"
-    },
-    {
-      "provider": "Nodeist",
-      "address": "https://rpc-source.nodeist.net"
-    },
-    {
-      "provider": "ITRocket",
-      "address": "https://source-mainnet-rpc.itrocket.net:443"
-    },
-    {
-      "provider": "StakeTown",
-      "address": "https://source-rpc.stake-town.com:443"
+      "provider": "Polkachu",
+      "address": "https://source-rpc.polkachu.com:443"
     }
   ],
   "snapshot_provider": "",


### PR DESCRIPTION
Updated SOURCE mainnet endpoints to only keep the ones that are currently reliable and show green on ping.pub (TCNetwork + Polkachu).