### PR TITLE
Add Safrochain mainnet (safrochain-1) to Ping.pub

### DIFF
--- a/chains/mainnet/safrochain.json
+++ b/chains/mainnet/safrochain.json
@@ -1,14 +1,26 @@
 {
   "chain_name": "safrochain",
-  "registry_name": "safrochain",
   "api": [
-    { "address": "https://api1.safrochain.network", "provider": "Safrochain Foundation" },
-    { "address": "https://api2.safrochain.network", "provider": "Safrochain Foundation" }
+    {
+      "provider": "Safrochain Foundation",
+      "address": "https://api1.safrochain.network"
+    },
+    {
+      "provider": "Safrochain Foundation",
+      "address": "https://api2.safrochain.network"
+    }
   ],
   "rpc": [
-    { "address": "https://rpc1.safrochain.network", "provider": "Safrochain Foundation" },
-    { "address": "https://rpc2.safrochain.network", "provider": "Safrochain Foundation" }
+    {
+      "provider": "Safrochain Foundation",
+      "address": "https://rpc1.safrochain.network"
+    },
+    {
+      "provider": "Safrochain Foundation",
+      "address": "https://rpc2.safrochain.network"
+    }
   ],
+  "snapshot_provider": "",
   "sdk_version": "0.50",
   "coin_type": "118",
   "min_tx_fee": "5000",
@@ -23,7 +35,5 @@
       "coingecko_id": "",
       "logo": "/logos/safrochain.png"
     }
-  ],
-  "keywords": ["cosmwasm", "ibc", "feeshare", "tokenfactory"],
-  "features": ["wasm+", "ibc", "ibc-transfer", "authz", "feegrant"]
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds Safrochain mainnet explorer config at `chains/mainnet/safrochain.json`
- Adds chain logos at `logos/safrochain.png` and `logos/safrochain.svg`
- Uses the standard Ping.pub mainnet format (same structure as scorum, juno, rebus) with no custom `features` field so all explorer menus are enabled by default

## Chain details

| Field | Value |
|---|---|
| Chain name | `safrochain` |
| Chain ID | `safrochain-1` |
| Bech32 prefix | `addr_safro` |
| Native denom | `usaf` (SAF, 6 decimals) |
| SDK | `0.50` |
| Coin type | `118` |
| Min tx fee | `5000` |
| Theme color | `#1D4ED8` |

## Endpoints

| Type | Provider | URL |
|---|---|---|
| REST | Safrochain Foundation | `https://api1.safrochain.network` |
| REST | Safrochain Foundation | `https://api2.safrochain.network` |
| RPC | Safrochain Foundation | `https://rpc1.safrochain.network` |
| RPC | Safrochain Foundation | `https://rpc2.safrochain.network` |

## Notes

- CORS is enabled on the REST endpoints (`Access-Control-Allow-Origin: *`)
- Bank denom metadata is configured on-chain (`usaf` / SAF)
- Config intentionally omits `registry_name` and `features` to match most mainnet chains and avoid sidebar menu filtering

## Test plan
